### PR TITLE
Add prepack scripts and fix package manifests

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -43,5 +43,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
   },
   "engines": {
     "node": ">=14"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -24,6 +24,7 @@
   "main": "lib/index.js",
   "types": "src/plugin-openapi.d.ts",
   "scripts": {
+    "prepack": "yarn build",
     "build": "tsc",
     "watch": "tsc --watch"
   },
@@ -33,7 +34,8 @@
     "@types/json-pointer": "^1.0.31",
     "@types/json-schema": "^7.0.9",
     "@types/lodash": "^4.14.176",
-    "@types/mustache": "^4.1.2"
+    "@types/mustache": "^4.1.2",
+    "typescript": "^4.4.4"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
@@ -59,5 +61,6 @@
   },
   "engines": {
     "node": ">=14"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -24,6 +24,7 @@
   "types": "src/theme-openapi.d.ts",
   "main": "lib/index.js",
   "scripts": {
+    "prepack": "yarn build",
     "build": "tsc --build && node ../../scripts/copyUntypedFiles.mjs && prettier --config ../../.prettierrc.json --write \"lib/theme/**/*.js\"",
     "watch": "concurrently --names \"lib,lib-next,tsc\" --kill-others \"yarn babel:lib --watch\" \"yarn babel:lib-next --watch\" \"yarn tsc --watch\""
   },
@@ -32,7 +33,9 @@
     "@types/crypto-js": "^4.1.0",
     "@types/file-saver": "^2.0.5",
     "@types/lodash": "^4.14.176",
-    "concurrently": "^5.2.0"
+    "concurrently": "^5.2.0",
+    "prettier": "^2.4.1",
+    "typescript": "^4.4.4"
   },
   "dependencies": {
     "@docusaurus/theme-common": ">=2.3.0 <2.5.0",
@@ -67,5 +70,6 @@
   },
   "engines": {
     "node": ">=14"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -290,7 +290,7 @@ function Body({
       <FormItem>
         <SchemaTabs className="openapi-tabs__schema" lazy>
           {/* @ts-ignore */}
-          <TabItem label="Default" value="default" default>
+          <TabItem label="Example (from schema)" value="Example (from schema)" default>
             <LiveApp action={dispatch} language={language} required={required}>
               {defaultBody}
             </LiveApp>


### PR DESCRIPTION
This should fix the issues we have installing using the Yarn Git protocol. To test this, in the Wiki `add/openapi-refs` branch, you should be able to do:

```
yarn add "docusaurus-plugin-openapi-docs@jlvandenhout/docusaurus-openapi-docs#workspace=docusaurus-plugin-openapi-docs&head=unify-tab-naming"
```

and

```
yarn add "docusaurus-theme-openapi-docs@jlvandenhout/docusaurus-openapi-docs#workspace=docusaurus-theme-openapi-docs&head=unify-tab-naming"
```